### PR TITLE
Fix frame and and bolt DarkIntensity issue

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/omni/AbstractBatteryView.java
+++ b/packages/SystemUI/src/com/android/systemui/omni/AbstractBatteryView.java
@@ -60,8 +60,8 @@ public abstract class AbstractBatteryView extends View implements BatteryControl
     protected int mLightModeBackgroundColor;
     protected int mLightModeFillColor;
     protected int mIconTint = Color.WHITE;
-    protected final Paint mBoltPaint;
-    protected final Paint mTextPaint;
+    protected float mOldDarkIntensity = 0f;
+    protected final Paint mBoltPaint, mTextPaint;
     protected int mTextSize;
     protected boolean mChargeColorEnable = true;
     protected int mTextWidth;
@@ -283,12 +283,17 @@ public abstract class AbstractBatteryView extends View implements BatteryControl
     protected abstract void applyStyle();
 
     protected void setDarkIntensity(float darkIntensity) {
+        if (darkIntensity == mOldDarkIntensity) {
+            return;
+        }
         int backgroundColor = getBackgroundColor(darkIntensity);
         int fillColor = getFillColor(darkIntensity);
         mIconTint = fillColor;
         mFrameColor = backgroundColor;
         mBoltPaint.setColor(fillColor);
+        mChargeColor = fillColor;
         invalidate();
+        mOldDarkIntensity = darkIntensity;
     }
 
     protected int getBackgroundColor(float darkIntensity) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarIconController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarIconController.java
@@ -45,6 +45,7 @@ import com.android.systemui.FontSizeUtils;
 import com.android.systemui.Interpolators;
 import com.android.systemui.R;
 import com.android.systemui.SystemUIFactory;
+import com.android.systemui.omni.AbstractBatteryView;
 import com.android.systemui.omni.BatteryViewManager;
 import com.android.systemui.statusbar.NotificationData;
 import com.android.systemui.statusbar.SignalClusterView;
@@ -83,6 +84,7 @@ public class StatusBarIconController extends StatusBarIconList implements Tunabl
 
     //private BatteryMeterView mBatteryMeterViewKeyguard;
     //private BatteryMeterView mBatteryMeterView;
+    private AbstractBatteryView mCurrentBatteryView;
     private BatteryViewManager mBatteryViewManager;
     private NetworkTraffic mNetworkTraffic;
     private TextView mClock;
@@ -569,7 +571,8 @@ public class StatusBarIconController extends StatusBarIconList implements Tunabl
             v.setImageTintList(ColorStateList.valueOf(getTint(mTintArea, v, mIconTint)));
         }
         mSignalCluster.setIconTint(mIconTint, mDarkIntensity, mTintArea);
-        mBatteryViewManager.setDarkIntensity(mDarkIntensity);
+        mBatteryViewManager.setDarkIntensity(
+                isInArea(mTintArea, mCurrentBatteryView) ? mDarkIntensity : 0);
         mClock.setTextColor(getTint(mTintArea, mClock, mIconTint));
         mLeftClock.setTextColor(getTint(mTintArea, mLeftClock, mIconTint));
         mCclock.setTextColor(getTint(mTintArea, mCclock, mIconTint));


### PR DESCRIPTION
While @ezio84's patch provided dark intensity to the new battery styles, it was half and half
while charging. This patch fixes that and makes it the way stock intended to.

Change-Id: I638186edd2d341becf00650a5f201c2087d3f400